### PR TITLE
Fix: Resolve site-wide theming and styling issues for Shadcn UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,367 +8,815 @@
 
 @layer base {
   :root {
-    /* Modern Typography */
+    /* Modern Typography (preserved from original globals.css) */
     --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     --font-mono: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
-    
-    /* V4 Emerald/Violet/Amber Base Colors */
-    --background: 152 100% 98%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 158 64% 52%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 152 50% 96%;
-    --secondary-foreground: 222.2 84% 4.9%;
-    --muted: 152 50% 96%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 152 50% 96%;
-    --accent-foreground: 222.2 84% 4.9%;
-    --destructive: 348 83% 47%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 152 30% 91%;
-    --input: 152 30% 91%;
-    --ring: 158 64% 52%;
-    --radius: 0.5rem;
 
-    /* V4 Trading-specific colors */
-    --trading-buy: 158 64% 52%;
-    --trading-sell: 348 83% 47%;
-    --trading-profit: 158 64% 52%;
-    --trading-loss: 348 83% 47%;
-    --trading-neutral: 152 30% 84%;
+    /* Primary Brand Colors (from globals-dark.css) */
+    --color-primary-blue: #3B82F6;
+    --color-primary-blue-light: #60A5FA;
+    --color-primary-blue-dark: #1D4ED8;
+    --color-primary-blue-bg: rgba(59, 130, 246, 0.1);
 
-    /* V4 Chart colors */
-    --chart-grid: 152 30% 91%;
-    --chart-axis: 215.4 16.3% 46.9%;
-    --chart-volume: 158 64% 52%;
-    --chart-indicator-sma: 271 91% 65%;
-    --chart-indicator-ema: 348 83% 47%;
-    --chart-indicator-rsi: 43 96% 56%;
-    --chart-indicator-macd: 158 64% 52%;
+    --color-primary-green: #10B981;
+    --color-primary-green-light: #34D399;
+    --color-primary-green-dark: #059669;
+    --color-primary-green-bg: rgba(16, 185, 129, 0.1);
 
-    /* V4 Status colors */
-    --status-online: 158 64% 52%;
-    --status-offline: 0 0% 45%;
-    --status-warning: 43 96% 56%;
-    --status-error: 348 83% 47%;
+    --color-primary-purple: #8B5CF6;
+    --color-primary-purple-light: #A78BFA;
+    --color-primary-purple-dark: #7C3AED;
+    --color-primary-purple-bg: rgba(139, 92, 246, 0.1);
+
+    /* Semantic Colors (from globals-dark.css) */
+    --color-success: #10B981;
+    --color-warning: #F59E0B;
+    --color-error: #EF4444;
+    --color-info: #3B82F6;
+
+    /* ShadCN CSS Variables - Light Theme (from globals-dark.css) */
+    --background: oklch(1.0000 0 0);
+    --foreground: oklch(0.3211 0 0);
+    --card: oklch(1.0000 0 0);
+    --card-foreground: oklch(0.3211 0 0);
+    --popover: oklch(1.0000 0 0);
+    --popover-foreground: oklch(0.3211 0 0);
+    --primary: oklch(0.6231 0.1880 259.8145);
+    --primary-foreground: oklch(1.0000 0 0);
+    --secondary: oklch(0.9670 0.0029 264.5419);
+    --secondary-foreground: oklch(0.4461 0.0263 256.8018);
+    --muted: oklch(0.9846 0.0017 247.8389);
+    --muted-foreground: oklch(0.5510 0.0234 264.3637);
+    --accent: oklch(0.9514 0.0250 236.8242);
+    --accent-foreground: oklch(0.3791 0.1378 265.5222);
+    --destructive: oklch(0.6368 0.2078 25.3313);
+    --destructive-foreground: oklch(1.0000 0 0);
+    --border: oklch(0.9276 0.0058 264.5313);
+    --input: oklch(0.9276 0.0058 264.5313);
+    --ring: oklch(0.6231 0.1880 259.8145);
+    --chart-1: oklch(0.6231 0.1880 259.8145);
+    --chart-2: oklch(0.5461 0.2152 262.8809);
+    --chart-3: oklch(0.4882 0.2172 264.3763);
+    --chart-4: oklch(0.4244 0.1809 265.6377);
+    --chart-5: oklch(0.3791 0.1378 265.5222);
+    --sidebar: oklch(0.9846 0.0017 247.8389);
+    --sidebar-foreground: oklch(0.3211 0 0);
+    --sidebar-primary: oklch(0.6231 0.1880 259.8145);
+    --sidebar-primary-foreground: oklch(1.0000 0 0);
+    --sidebar-accent: oklch(0.9514 0.0250 236.8242);
+    --sidebar-accent-foreground: oklch(0.3791 0.1378 265.5222);
+    --sidebar-border: oklch(0.9276 0.0058 264.5313);
+    --sidebar-ring: oklch(0.6231 0.1880 259.8145);
+    --radius: 0.375rem; /* Default radius from ShadCN Light theme */
   }
 
   .dark {
-    /* V4 Dark mode base colors */
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 158 64% 52%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 158 32% 17%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 158 32% 17%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 158 32% 17%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 348 83% 47%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 158 32% 17%;
-    --input: 158 32% 17%;
-    --ring: 158 64% 52%;
+    /* ShadCN CSS Variables - Dark Theme (from globals-dark.css) */
+    --background: oklch(0.2046 0 0);
+    --foreground: oklch(0.9219 0 0);
+    --card: oklch(0.2686 0 0);
+    --card-foreground: oklch(0.9219 0 0);
+    --popover: oklch(0.2686 0 0);
+    --popover-foreground: oklch(0.9219 0 0);
+    --primary: oklch(0.6231 0.1880 259.8145);
+    --primary-foreground: oklch(1.0000 0 0);
+    --secondary: oklch(0.2686 0 0);
+    --secondary-foreground: oklch(0.9219 0 0);
+    --muted: oklch(0.2686 0 0);
+    --muted-foreground: oklch(0.7155 0 0);
+    --accent: oklch(0.4548 0.1467 265.7499);
+    --accent-foreground: oklch(0.8823 0.0571 254.1284);
+    --destructive: oklch(0.6368 0.2078 25.3313);
+    --destructive-foreground: oklch(1.0000 0 0);
+    --border: oklch(0.3715 0 0);
+    --input: oklch(0.3715 0 0);
+    --ring: oklch(0.6231 0.1880 259.8145);
+    --chart-1: oklch(0.7137 0.1434 254.6240);
+    --chart-2: oklch(0.6231 0.1880 259.8145);
+    --chart-3: oklch(0.5461 0.2152 262.8809);
+    --chart-4: oklch(0.4882 0.2172 264.3763);
+    --chart-5: oklch(0.4244 0.1809 265.6377);
+    --sidebar: oklch(0.2046 0 0);
+    --sidebar-foreground: oklch(0.9219 0 0);
+    --sidebar-primary: oklch(0.6231 0.1880 259.8145);
+    --sidebar-primary-foreground: oklch(1.0000 0 0);
+    --sidebar-accent: oklch(0.3791 0.1378 265.5222);
+    --sidebar-accent-foreground: oklch(0.8823 0.0571 254.1284);
+    --sidebar-border: oklch(0.3715 0 0);
+    --sidebar-ring: oklch(0.6231 0.1880 259.8145);
+    /* --radius: 0.375rem; */ /* Inherits from :root or specific theme if overridden */
+  }
 
-    /* V4 Dark mode trading colors */
-    --trading-buy: 158 64% 52%;
-    --trading-sell: 348 83% 47%;
-    --trading-profit: 158 64% 52%;
-    --trading-loss: 348 83% 47%;
-    --trading-neutral: 215 20.2% 65.1%;
+  .green {
+    /* ShadCN CSS Variables - Green Theme (from globals-dark.css) */
+    --background: oklch(0.9911 0 0);
+    --foreground: oklch(0.2046 0 0);
+    --card: oklch(0.9911 0 0);
+    --card-foreground: oklch(0.2046 0 0);
+    --popover: oklch(0.9911 0 0);
+    --popover-foreground: oklch(0.4386 0 0);
+    --primary: oklch(0.8348 0.1302 160.9080);
+    --primary-foreground: oklch(0.2626 0.0147 166.4589);
+    --secondary: oklch(0.9940 0 0);
+    --secondary-foreground: oklch(0.2046 0 0);
+    --muted: oklch(0.9461 0 0);
+    --muted-foreground: oklch(0.2435 0 0);
+    --accent: oklch(0.9461 0 0);
+    --accent-foreground: oklch(0.2435 0 0);
+    --destructive: oklch(0.5523 0.1927 32.7272);
+    --destructive-foreground: oklch(0.9934 0.0032 17.2118);
+    --border: oklch(0.9037 0 0);
+    --input: oklch(0.9731 0 0);
+    --ring: oklch(0.8348 0.1302 160.9080);
+    --chart-1: oklch(0.8348 0.1302 160.9080);
+    --chart-2: oklch(0.6231 0.1880 259.8145);
+    --chart-3: oklch(0.6056 0.2189 292.7172);
+    --chart-4: oklch(0.7686 0.1647 70.0804);
+    --chart-5: oklch(0.6959 0.1491 162.4796);
+    --sidebar: oklch(0.9911 0 0);
+    --sidebar-foreground: oklch(0.5452 0 0);
+    --sidebar-primary: oklch(0.8348 0.1302 160.9080);
+    --sidebar-primary-foreground: oklch(0.2626 0.0147 166.4589);
+    --sidebar-accent: oklch(0.9461 0 0);
+    --sidebar-accent-foreground: oklch(0.2435 0 0);
+    --sidebar-border: oklch(0.9037 0 0);
+    --sidebar-ring: oklch(0.8348 0.1302 160.9080);
+    --radius: 0.5rem;
+    --tracking-normal: 0.025em;
+  }
 
-    /* V4 Dark mode chart colors */
-    --chart-grid: 158 32% 17%;
-    --chart-axis: 215 20.2% 65.1%;
-    --chart-volume: 158 64% 52%;
-    --chart-indicator-sma: 271 91% 65%;
-    --chart-indicator-ema: 348 83% 47%;
-    --chart-indicator-rsi: 43 96% 56%;
-    --chart-indicator-macd: 158 64% 52%;
+  .green.dark {
+    /* ShadCN CSS Variables - Green Dark Theme (from globals-dark.css) */
+    --background: oklch(0.1822 0 0);
+    --foreground: oklch(0.9288 0.0126 255.5078);
+    --card: oklch(0.2046 0 0);
+    --card-foreground: oklch(0.9288 0.0126 255.5078);
+    --popover: oklch(0.2603 0 0);
+    --popover-foreground: oklch(0.7348 0 0);
+    --primary: oklch(0.4365 0.1044 156.7556);
+    --primary-foreground: oklch(0.9213 0.0135 167.1556);
+    --secondary: oklch(0.2603 0 0);
+    --secondary-foreground: oklch(0.9851 0 0);
+    --muted: oklch(0.2393 0 0);
+    --muted-foreground: oklch(0.7122 0 0);
+    --accent: oklch(0.3132 0 0);
+    --accent-foreground: oklch(0.9851 0 0);
+    --destructive: oklch(0.3123 0.0852 29.7877);
+    --destructive-foreground: oklch(0.9368 0.0045 34.3092);
+    --border: oklch(0.2809 0 0);
+    --input: oklch(0.2603 0 0);
+    --ring: oklch(0.8003 0.1821 151.7110);
+    --chart-1: oklch(0.8003 0.1821 151.7110);
+    --chart-2: oklch(0.7137 0.1434 254.6240);
+    --chart-3: oklch(0.7090 0.1592 293.5412);
+    --chart-4: oklch(0.8369 0.1644 84.4286);
+    --chart-5: oklch(0.7845 0.1325 181.9120);
+    --sidebar: oklch(0.1822 0 0);
+    --sidebar-foreground: oklch(0.6301 0 0);
+    --sidebar-primary: oklch(0.4365 0.1044 156.7556);
+    --sidebar-primary-foreground: oklch(0.9213 0.0135 167.1556);
+    --sidebar-accent: oklch(0.3132 0 0);
+    --sidebar-accent-foreground: oklch(0.9851 0 0);
+    --sidebar-border: oklch(0.2809 0 0);
+    --sidebar-ring: oklch(0.8003 0.1821 151.7110);
+    /* --radius: 0.5rem; */ /* Inherits from .green */
+  }
 
-    /* V4 Dark mode status colors */
-    --status-online: 158 64% 52%;
-    --status-offline: 0 0% 55%;
-    --status-warning: 43 96% 56%;
-    --status-error: 348 83% 47%;
+  .neo {
+    /* ShadCN CSS Variables - Neo Brutalist Theme (from globals-dark.css) */
+    --background: oklch(1.0000 0 0);
+    --foreground: oklch(0 0 0);
+    --card: oklch(1.0000 0 0);
+    --card-foreground: oklch(0 0 0);
+    --popover: oklch(1.0000 0 0);
+    --popover-foreground: oklch(0 0 0);
+    --primary: oklch(0.6489 0.2370 26.9728);
+    --primary-foreground: oklch(1.0000 0 0);
+    --secondary: oklch(0.9680 0.2110 109.7692);
+    --secondary-foreground: oklch(0 0 0);
+    --muted: oklch(0.9551 0 0);
+    --muted-foreground: oklch(0.3211 0 0);
+    --accent: oklch(0.5635 0.2408 260.8178);
+    --accent-foreground: oklch(1.0000 0 0);
+    --destructive: oklch(0 0 0);
+    --destructive-foreground: oklch(1.0000 0 0);
+    --border: oklch(0 0 0);
+    --input: oklch(0 0 0);
+    --ring: oklch(0.6489 0.2370 26.9728);
+    --chart-1: oklch(0.6489 0.2370 26.9728);
+    --chart-2: oklch(0.9680 0.2110 109.7692);
+    --chart-3: oklch(0.5635 0.2408 260.8178);
+    --chart-4: oklch(0.7323 0.2492 142.4953);
+    --chart-5: oklch(0.5931 0.2726 328.3634);
+    --sidebar: oklch(0.9551 0 0);
+    --sidebar-foreground: oklch(0 0 0);
+    --sidebar-primary: oklch(0.6489 0.2370 26.9728);
+    --sidebar-primary-foreground: oklch(1.0000 0 0);
+    --sidebar-accent: oklch(0.5635 0.2408 260.8178);
+    --sidebar-accent-foreground: oklch(1.0000 0 0);
+    --sidebar-border: oklch(0 0 0);
+    --sidebar-ring: oklch(0.6489 0.2370 26.9728);
+    --radius: 0px;
+    --shadow-2xs: 4px 4px 0px 0px hsl(0 0% 0% / 0.50);
+    --shadow-xs: 4px 4px 0px 0px hsl(0 0% 0% / 0.50);
+    --shadow-sm: 4px 4px 0px 0px hsl(0 0% 0% / 1.00), 4px 1px 2px -1px hsl(0 0% 0% / 1.00);
+    --shadow: 4px 4px 0px 0px hsl(0 0% 0% / 1.00), 4px 1px 2px -1px hsl(0 0% 0% / 1.00);
+    --shadow-md: 4px 4px 0px 0px hsl(0 0% 0% / 1.00), 4px 2px 4px -1px hsl(0 0% 0% / 1.00);
+    --shadow-lg: 4px 4px 0px 0px hsl(0 0% 0% / 1.00), 4px 4px 6px -1px hsl(0 0% 0% / 1.00);
+    --shadow-xl: 4px 4px 0px 0px hsl(0 0% 0% / 1.00), 4px 8px 10px -1px hsl(0 0% 0% / 1.00);
+    --shadow-2xl: 4px 4px 0px 0px hsl(0 0% 0% / 2.50);
+  }
+
+  .neo.dark {
+    /* ShadCN CSS Variables - Neo Brutalist Dark Theme (from globals-dark.css) */
+    --background: oklch(0 0 0);
+    --foreground: oklch(1.0000 0 0);
+    --card: oklch(0.3211 0 0);
+    --card-foreground: oklch(1.0000 0 0);
+    --popover: oklch(0.3211 0 0);
+    --popover-foreground: oklch(1.0000 0 0);
+    --primary: oklch(0.7044 0.1872 23.1858);
+    --primary-foreground: oklch(0 0 0);
+    --secondary: oklch(0.9691 0.2005 109.6228);
+    --secondary-foreground: oklch(0 0 0);
+    --muted: oklch(0.3211 0 0);
+    --muted-foreground: oklch(0.8452 0 0);
+    --accent: oklch(0.6755 0.1765 252.2592);
+    --accent-foreground: oklch(0 0 0);
+    --destructive: oklch(1.0000 0 0);
+    --destructive-foreground: oklch(0 0 0);
+    --border: oklch(1.0000 0 0);
+    --input: oklch(1.0000 0 0);
+    --ring: oklch(0.7044 0.1872 23.1858);
+    --chart-1: oklch(0.7044 0.1872 23.1858);
+    --chart-2: oklch(0.9691 0.2005 109.6228);
+    --chart-3: oklch(0.6755 0.1765 252.2592);
+    --chart-4: oklch(0.7395 0.2268 142.8504);
+    --chart-5: oklch(0.6131 0.2458 328.0714);
+    --sidebar: oklch(0 0 0);
+    --sidebar-foreground: oklch(1.0000 0 0);
+    --sidebar-primary: oklch(0.7044 0.1872 23.1858);
+    --sidebar-primary-foreground: oklch(0 0 0);
+    --sidebar-accent: oklch(0.6755 0.1765 252.2592);
+    --sidebar-accent-foreground: oklch(0 0 0);
+    --sidebar-border: oklch(1.0000 0 0);
+    --sidebar-ring: oklch(0.7044 0.1872 23.1858);
+    /* --radius: 0px; */ /* Inherits from .neo */
+    /* Shadows inherit from .neo */
+  }
+
+  .cyber {
+    /* ShadCN CSS Variables - Cyberpunk Theme (from globals-dark.css) */
+    --background: oklch(0.8452 0 0);
+    --foreground: oklch(0.2393 0 0);
+    --card: oklch(0.7572 0 0);
+    --card-foreground: oklch(0.2393 0 0);
+    --popover: oklch(0.7572 0 0);
+    --popover-foreground: oklch(0.2393 0 0);
+    --primary: oklch(0.5016 0.1887 27.4816);
+    --primary-foreground: oklch(1.0000 0 0);
+    --secondary: oklch(0.4955 0.0896 126.1858);
+    --secondary-foreground: oklch(1.0000 0 0);
+    --muted: oklch(0.7826 0 0);
+    --muted-foreground: oklch(0.4091 0 0);
+    --accent: oklch(0.5880 0.0993 245.7394);
+    --accent-foreground: oklch(1.0000 0 0);
+    --destructive: oklch(0.7076 0.1975 46.4558);
+    --destructive-foreground: oklch(0 0 0);
+    --border: oklch(0.4313 0 0);
+    --input: oklch(0.4313 0 0);
+    --ring: oklch(0.5016 0.1887 27.4816);
+    --chart-1: oklch(0.5016 0.1887 27.4816);
+    --chart-2: oklch(0.4955 0.0896 126.1858);
+    --chart-3: oklch(0.5880 0.0993 245.7394);
+    --chart-4: oklch(0.7076 0.1975 46.4558);
+    --chart-5: oklch(0.5656 0.0431 40.4319);
+    --sidebar: oklch(0.7572 0 0);
+    --sidebar-foreground: oklch(0.2393 0 0);
+    --sidebar-primary: oklch(0.5016 0.1887 27.4816);
+    --sidebar-primary-foreground: oklch(1.0000 0 0);
+    --sidebar-accent: oklch(0.5880 0.0993 245.7394);
+    --sidebar-accent-foreground: oklch(1.0000 0 0);
+    --sidebar-border: oklch(0.4313 0 0);
+    --sidebar-ring: oklch(0.5016 0.1887 27.4816);
+    --radius: 0px;
+    --shadow-2xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.20);
+    --shadow-xs: 0px 2px 4px 0px hsl(0 0% 0% / 0.20);
+    --shadow-sm: 0px 2px 4px 0px hsl(0 0% 0% / 0.40), 0px 1px 2px -1px hsl(0 0% 0% / 0.40);
+    --shadow: 0px 2px 4px 0px hsl(0 0% 0% / 0.40), 0px 1px 2px -1px hsl(0 0% 0% / 0.40);
+    --shadow-md: 0px 2px 4px 0px hsl(0 0% 0% / 0.40), 0px 2px 4px -1px hsl(0 0% 0% / 0.40);
+    --shadow-lg: 0px 2px 4px 0px hsl(0 0% 0% / 0.40), 0px 4px 6px -1px hsl(0 0% 0% / 0.40);
+    --shadow-xl: 0px 2px 4px 0px hsl(0 0% 0% / 0.40), 0px 8px 10px -1px hsl(0 0% 0% / 0.40);
+    --shadow-2xl: 0px 2px 4px 0px hsl(0 0% 0% / 1.00);
+  }
+
+  .cyber.dark {
+    /* ShadCN CSS Variables - Cyberpunk Dark Theme (from globals-dark.css) */
+    --background: oklch(0.2178 0 0);
+    --foreground: oklch(0.9067 0 0);
+    --card: oklch(0.2850 0 0);
+    --card-foreground: oklch(0.9067 0 0);
+    --popover: oklch(0.2850 0 0);
+    --popover-foreground: oklch(0.9067 0 0);
+    --primary: oklch(0.6083 0.2090 27.0276);
+    --primary-foreground: oklch(1.0000 0 0);
+    --secondary: oklch(0.6423 0.1467 133.0145);
+    --secondary-foreground: oklch(0 0 0);
+    --muted: oklch(0.2645 0 0);
+    --muted-foreground: oklch(0.7058 0 0);
+    --accent: oklch(0.7482 0.1235 244.7492);
+    --accent-foreground: oklch(0 0 0);
+    --destructive: oklch(0.7839 0.1719 68.0943);
+    --destructive-foreground: oklch(0 0 0);
+    --border: oklch(0.4091 0 0);
+    --input: oklch(0.4091 0 0);
+    --ring: oklch(0.6083 0.2090 27.0276);
+    --chart-1: oklch(0.6083 0.2090 27.0276);
+    --chart-2: oklch(0.6423 0.1467 133.0145);
+    --chart-3: oklch(0.7482 0.1235 244.7492);
+    --chart-4: oklch(0.7839 0.1719 68.0943);
+    --chart-5: oklch(0.6471 0.0334 40.7963);
+    --sidebar: oklch(0.1913 0 0);
+    --sidebar-foreground: oklch(0.9067 0 0);
+    --sidebar-primary: oklch(0.6083 0.2090 27.0276);
+    --sidebar-primary-foreground: oklch(1.0000 0 0);
+    --sidebar-accent: oklch(0.7482 0.1235 244.7492);
+    --sidebar-accent-foreground: oklch(0 0 0);
+    --sidebar-border: oklch(0.4091 0 0);
+    --sidebar-ring: oklch(0.6083 0.2090 27.0276);
+    /* --radius: 0px; */ /* Inherits from .cyber */
+    /* Shadows inherit from .cyber, but globals-dark.css had specific ones. Using those: */
+    --shadow-2xs: 0px 2px 5px 0px hsl(0 0% 0% / 0.30);
+    --shadow-xs: 0px 2px 5px 0px hsl(0 0% 0% / 0.30);
+    --shadow-sm: 0px 2px 5px 0px hsl(0 0% 0% / 0.60), 0px 1px 2px -1px hsl(0 0% 0% / 0.60);
+    --shadow: 0px 2px 5px 0px hsl(0 0% 0% / 0.60), 0px 1px 2px -1px hsl(0 0% 0% / 0.60);
+    --shadow-md: 0px 2px 5px 0px hsl(0 0% 0% / 0.60), 0px 2px 4px -1px hsl(0 0% 0% / 0.60);
+    --shadow-lg: 0px 2px 5px 0px hsl(0 0% 0% / 0.60), 0px 4px 6px -1px hsl(0 0% 0% / 0.60);
+    --shadow-xl: 0px 2px 5px 0px hsl(0 0% 0% / 0.60), 0px 8px 10px -1px hsl(0 0% 0% / 0.60);
+    --shadow-2xl: 0px 2px 5px 0px hsl(0 0% 0% / 1.50);
+
+    /* Typography and other utility vars from globals-dark.css cyber.dark scope */
+    /* These will only apply if .cyber.dark is active on a parent */
+    --font-primary: 'Inter', 'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif; /* Overrides global --font-sans */
+    --font-secondary: 'Inter', 'SF Pro Text', -apple-system, BlinkMacSystemFont, sans-serif;
+    /* --font-mono is inherited from :root */
+
+    --text-xs: 0.75rem; --text-sm: 0.875rem; --text-base: 1rem; --text-lg: 1.125rem;
+    --text-xl: 1.25rem; --text-2xl: 1.5rem; --text-3xl: 1.875rem; --text-4xl: 2.25rem; --text-5xl: 3rem;
+
+    --font-light: 300; --font-regular: 400; --font-medium: 500; --font-semibold: 600; --font-bold: 700;
+
+    --leading-tight: 1.25; --leading-normal: 1.5; --leading-relaxed: 1.75;
+
+    --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem; --space-5: 1.25rem;
+    --space-6: 1.5rem; --space-8: 2rem; --space-10: 2.5rem; --space-12: 3rem; --space-16: 4rem;
+
+    --radius-sm: 0.375rem; --radius-md: 0.5rem; --radius-lg: 0.75rem; --radius-xl: 1rem;
+    --radius-2xl: 1.5rem; --radius-full: 9999px;
+
+    --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    --transition-normal: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+    --transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 }
 
 @layer base {
+  /* Preserved base styles from original globals.css */
   * {
-    @apply border-border;
+    @apply border-border; /* Uses new theme variable */
   }
   
   body {
-    @apply bg-background text-foreground;
-    font-family: var(--font-sans);
+    @apply bg-background text-foreground; /* Uses new theme variables */
+    font-family: var(--font-sans); /* Uses theme variable */
     font-feature-settings: "rlig" 1, "calt" 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
   
-  /* Modern Typography Scale */
-  h1, h2, h3, h4, h5, h6 {
-    @apply font-sans tracking-tight;
-  }
+  h1, h2, h3, h4, h5, h6 { @apply font-sans tracking-tight; }
+  h1 { @apply text-4xl md:text-5xl font-bold; }
+  h2 { @apply text-3xl md:text-4xl font-semibold; }
+  h3 { @apply text-2xl md:text-3xl font-semibold; }
+  h4 { @apply text-xl md:text-2xl font-medium; }
+  h5 { @apply text-lg md:text-xl font-medium; }
+  h6 { @apply text-base md:text-lg font-medium; }
+  p { @apply text-base leading-relaxed; }
   
-  h1 {
-    @apply text-4xl md:text-5xl font-bold;
-  }
-  
-  h2 {
-    @apply text-3xl md:text-4xl font-semibold;
-  }
-  
-  h3 {
-    @apply text-2xl md:text-3xl font-semibold;
-  }
-  
-  h4 {
-    @apply text-xl md:text-2xl font-medium;
-  }
-  
-  h5 {
-    @apply text-lg md:text-xl font-medium;
-  }
-  
-  h6 {
-    @apply text-base md:text-lg font-medium;
-  }
-  
-  p {
-    @apply text-base leading-relaxed;
-  }
-  
-  /* Ensure proper contrast for dark backgrounds */
-  .dark-bg-light-text {
-    @apply text-white;
-  }
-  
+  .dark-bg-light-text { @apply text-white; }
   .dark-bg-light-text h1,
   .dark-bg-light-text h2,
   .dark-bg-light-text h3,
   .dark-bg-light-text h4,
   .dark-bg-light-text h5,
   .dark-bg-light-text h6,
-  .dark-bg-light-text p {
-    @apply text-white;
-  }
-  
-  .dark-bg-light-text .text-muted-foreground {
-    @apply text-gray-300;
-  }
+  .dark-bg-light-text p { @apply text-white; }
+  .dark-bg-light-text .text-muted-foreground { @apply text-gray-300; }
 
-  /* Scrollbar styling */
-  ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
+  ::-webkit-scrollbar { width: 8px; height: 8px; }
+  ::-webkit-scrollbar-track { @apply bg-secondary; } /* Uses new theme variable */
+  ::-webkit-scrollbar-thumb { @apply bg-muted-foreground rounded-md; } /* Uses new theme variable */
+  ::-webkit-scrollbar-thumb:hover { @apply bg-foreground; } /* Uses new theme variable */
 
-  ::-webkit-scrollbar-track {
-    @apply bg-secondary;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    @apply bg-muted-foreground rounded-md;
-  }
-
-  ::-webkit-scrollbar-thumb:hover {
-    @apply bg-foreground;
-  }
-
-  /* Focus styles */
-  *:focus-visible {
-    @apply ring-2 ring-ring ring-offset-2 ring-offset-background outline-none;
-  }
-
-  /* Selection styles */
-  ::selection {
-    @apply bg-primary text-primary-foreground;
-  }
+  *:focus-visible { @apply ring-2 ring-ring ring-offset-2 ring-offset-background outline-none; } /* Uses new theme variables */
+  ::selection { @apply bg-primary text-primary-foreground; } /* Uses new theme variables */
 }
 
 @layer components {
-  /* Trading-specific component styles */
-  .trading-card {
-    @apply bg-card text-card-foreground border border-border rounded-lg p-4 shadow-sm;
-  }
+  /* Original component styles from globals.css */
+  .trading-card { @apply bg-card text-card-foreground border border-border rounded-lg p-4 shadow-sm; }
+  .trading-card-header { @apply flex items-center justify-between pb-2 mb-4 border-b border-border; }
+  .trading-button-buy { @apply bg-trading-buy text-white hover:bg-trading-buy/90 focus:ring-trading-buy; }
+  .trading-button-sell { @apply bg-trading-sell text-white hover:bg-trading-sell/90 focus:ring-trading-sell; }
+  .price-display { @apply font-mono text-lg font-semibold; }
+  .price-positive { @apply text-trading-profit; }
+  .price-negative { @apply text-trading-loss; }
+  .price-neutral { @apply text-trading-neutral; }
+  .status-indicator { @apply inline-block w-2 h-2 rounded-full mr-2; }
+  .status-online { @apply bg-status-online; }
+  .status-offline { @apply bg-status-offline; }
+  .status-warning { @apply bg-status-warning; }
+  .status-error { @apply bg-status-error; }
+  .chart-container { @apply relative w-full bg-card border border-border rounded-lg overflow-hidden; }
+  .chart-toolbar { @apply flex items-center justify-between p-3 bg-muted/30 border-b border-border; }
+  .nav-link { @apply flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors; }
+  .nav-link-active { @apply bg-emerald-500 text-white; } /* Note: hardcoded color, may need theme var */
+  .nav-link-inactive { @apply text-muted-foreground hover:text-foreground hover:bg-accent; }
+  .data-table { @apply w-full border-collapse border border-border rounded-lg overflow-hidden; }
+  .data-table th { @apply bg-muted/50 px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider border-b border-border; }
+  .data-table td { @apply px-4 py-3 text-sm border-b border-border; }
+  .data-table tr:hover { @apply bg-muted/30; }
+  .animate-pulse-slow { animation: pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite; }
+  /* .animate-fade-in defined with keyframes later */
+  /* .animate-slide-in defined with keyframes later */
 
-  .trading-card-header {
-    @apply flex items-center justify-between pb-2 mb-4 border-b border-border;
+  /* Component styles from globals-dark.css */
+  .dashboard-container {
+    display: flex;
+    min-height: 100vh;
+    /* width: 100vw; */ /* Avoid 100vw due to scrollbar issues, let it be 100% or auto */
+    background-color: hsl(var(--background)); /* Removed !important */
+    margin: 0;
+    padding: 0;
+    flex-direction: column;
   }
+  @media (min-width: 1024px) { .dashboard-container { flex-direction: row; } }
 
-  .trading-button-buy {
-    @apply bg-trading-buy text-white hover:bg-trading-buy/90 focus:ring-trading-buy;
-  }
-
-  .trading-button-sell {
-    @apply bg-trading-sell text-white hover:bg-trading-sell/90 focus:ring-trading-sell;
-  }
-
-  .price-display {
-    @apply font-mono text-lg font-semibold;
-  }
-
-  .price-positive {
-    @apply text-trading-profit;
-  }
-
-  .price-negative {
-    @apply text-trading-loss;
-  }
-
-  .price-neutral {
-    @apply text-trading-neutral;
-  }
-
-  .status-indicator {
-    @apply inline-block w-2 h-2 rounded-full mr-2;
-  }
-
-  .status-online {
-    @apply bg-status-online;
-  }
-
-  .status-offline {
-    @apply bg-status-offline;
-  }
-
-  .status-warning {
-    @apply bg-status-warning;
-  }
-
-  .status-error {
-    @apply bg-status-error;
-  }
-
-  /* Chart container styles */
-  .chart-container {
-    @apply relative w-full bg-card border border-border rounded-lg overflow-hidden;
-  }
-
-  .chart-toolbar {
-    @apply flex items-center justify-between p-3 bg-muted/30 border-b border-border;
-  }
-
-  /* Navigation styles */
-  .nav-link {
-    @apply flex items-center px-3 py-2 text-sm font-medium rounded-md transition-colors;
-  }
-
-  .nav-link-active {
-    @apply bg-emerald-500 text-white;
-  }
-
-  .nav-link-inactive {
-    @apply text-muted-foreground hover:text-foreground hover:bg-accent;
-  }
-
-  /* Data table styles */
-  .data-table {
-    @apply w-full border-collapse border border-border rounded-lg overflow-hidden;
-  }
-
-  .data-table th {
-    @apply bg-muted/50 px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider border-b border-border;
-  }
-
-  .data-table td {
-    @apply px-4 py-3 text-sm border-b border-border;
-  }
-
-  .data-table tr:hover {
-    @apply bg-muted/30;
-  }
-
-  /* Animation helpers */
-  .animate-pulse-slow {
-    animation: pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite;
-  }
-
-  .animate-fade-in {
-    animation: fadeIn 0.5s ease-in-out;
-  }
-
-  .animate-slide-in {
-    animation: slideIn 0.3s ease-out;
-  }
-}
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes slideIn {
-  from {
+  .sidebar-dark { /* Name kept, uses theme vars */
+    background-color: hsl(var(--sidebar));
+    border-right: 1px solid hsl(var(--sidebar-border));
+    color: hsl(var(--sidebar-foreground));
+    width: 100%;
+    height: auto;
+    overflow-y: auto;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 50;
     transform: translateX(-100%);
+    transition: transform var(--transition-normal, 200ms cubic-bezier(0.4, 0, 0.2, 1));
   }
-  to {
-    transform: translateX(0);
+  .sidebar-dark.open { transform: translateX(0); }
+  @media (min-width: 1024px) {
+    .sidebar-dark {
+      position: static; width: 280px; height: 100vh;
+      transform: translateX(0); flex-shrink: 0;
+    }
+  }
+  .sidebar-header {
+    padding: var(--space-6, 1.5rem);
+    border-bottom: 1px solid hsl(var(--sidebar-border));
+  }
+  .sidebar-nav {
+    padding: var(--space-4, 1rem);
+    display: flex; flex-direction: column;
+    gap: var(--space-2, 0.5rem);
+  }
+  .sidebar-link {
+    display: flex; align-items: center;
+    gap: var(--space-3, 0.75rem);
+    padding: var(--space-3, 0.75rem) var(--space-4, 1rem);
+    border-radius: var(--radius-lg, 0.75rem);
+    color: hsl(var(--sidebar-foreground));
+    text-decoration: none;
+    font-weight: var(--font-medium, 500);
+    font-size: var(--text-sm, 0.875rem);
+    transition: all var(--transition-normal, 200ms cubic-bezier(0.4, 0, 0.2, 1));
+    border: none; background: none; cursor: pointer;
+    width: 100%; text-align: left;
+  }
+  .sidebar-link:hover {
+    background-color: hsl(var(--sidebar-accent));
+    color: hsl(var(--sidebar-accent-foreground));
+    transform: translateX(4px);
+  }
+  .sidebar-link.active {
+    background-color: hsl(var(--sidebar-primary));
+    color: hsl(var(--sidebar-primary-foreground));
+    /* border-left: 3px solid hsl(var(--sidebar-primary)); */ /* Alternative style */
+  }
+
+  .main-content {
+    flex: 1; display: flex; flex-direction: column;
+    min-height: 100vh; width: 100%;
+    background-color: hsl(var(--background)); /* Removed !important */
+    overflow-x: hidden; margin: 0; padding: 0;
+  }
+  @media (min-width: 1024px) { .main-content { width: calc(100% - 280px); } }
+
+  .dashboard-header {
+    background-color: hsl(var(--card));
+    border-bottom: 1px solid hsl(var(--border));
+    padding: var(--space-4, 1rem) var(--space-6, 1.5rem);
+    box-shadow: var(--shadow-sm, 0 1px 2px 0 rgba(0,0,0,0.05)); /* Provide fallback for shadow */
+    position: sticky; top: 0; z-index: 40;
+  }
+  .dashboard-content {
+    flex: 1; display: flex; flex-direction: column;
+    background-color: hsl(var(--background)); /* Removed !important */
+    /* height: calc(100vh - 80px); */ /* Avoid fixed height subtraction if possible */
+    min-height: calc(100vh - 80px); /* Use min-height if header is fixed 80px */
+    width: 100%; overflow: hidden; margin: 0; padding: 0;
+  }
+
+  .card-dark, .modern-card, [data-radix-card], .card { /* .card might conflict if not careful with Tailwind base */
+    background-color: hsl(var(--card)); /* Removed !important */
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius, 0.375rem);
+    padding: var(--space-6, 1.5rem);
+    box-shadow: var(--shadow-md, 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06));
+    transition: all var(--transition-normal, 200ms cubic-bezier(0.4, 0, 0.2, 1));
+    overflow: hidden;
+    color: hsl(var(--card-foreground)); /* Removed !important */
+  }
+  .card-dark:hover, .modern-card:hover, [data-radix-card]:hover, .card:hover {
+    box-shadow: var(--shadow-lg, 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05));
+    border-color: hsl(var(--border) / 0.8);
+    transform: translateY(-2px);
+  }
+
+  .metric-card-dark {
+    background-color: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius, 0.375rem);
+    padding: var(--space-6, 1.5rem);
+    box-shadow: var(--shadow-md, 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06));
+    transition: all var(--transition-normal, 200ms cubic-bezier(0.4, 0, 0.2, 1));
+    position: relative; overflow: hidden;
+  }
+  .metric-card-dark::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+    background: linear-gradient(90deg, hsl(var(--primary)), hsl(var(--chart-2, var(--primary)) / 0.8));
+  }
+  .metric-title-dark {
+    font-size: var(--text-sm, 0.875rem); color: hsl(var(--muted-foreground));
+    font-weight: var(--font-medium, 500); margin-bottom: var(--space-2, 0.5rem);
+    text-transform: uppercase; letter-spacing: 0.5px;
+  }
+  .metric-value-dark {
+    font-size: var(--text-3xl, 1.875rem); font-weight: var(--font-bold, 700);
+    color: hsl(var(--foreground)); margin-bottom: var(--space-2, 0.5rem);
+    line-height: var(--leading-tight, 1.25);
+  }
+  .metric-change-dark {
+    font-size: var(--text-sm, 0.875rem); font-weight: var(--font-medium, 500);
+    display: flex; align-items: center; gap: var(--space-1, 0.25rem);
+  }
+  .metric-change-dark.positive { color: var(--color-success, #10B981); }
+  .metric-change-dark.negative { color: var(--color-error, #EF4444); }
+  .metric-change-dark.neutral { color: hsl(var(--muted-foreground) / 0.8); }
+
+  .nav-tabs-dark {
+    background-color: hsl(var(--muted)); border: 1px solid hsl(var(--border));
+    border-radius: var(--radius, 0.375rem); padding: var(--space-2, 0.5rem);
+    margin: var(--space-4, 1rem) var(--space-6, 1.5rem) 0 var(--space-6, 1.5rem);
+    display: flex; gap: var(--space-1, 0.25rem); flex-shrink: 0;
+    overflow-x: auto; scrollbar-width: none; -ms-overflow-style: none; flex-wrap: nowrap;
+  }
+  .nav-tabs-dark::-webkit-scrollbar { display: none; }
+  @media (max-width: 768px) { .nav-tabs-dark { margin: var(--space-2, 0.5rem) var(--space-4, 1rem) 0 var(--space-4, 1rem); } }
+  @media (min-width: 768px) { .nav-tabs-dark { flex-wrap: wrap; overflow-x: visible; justify-content: center; } }
+  @media (min-width: 1024px) { .nav-tabs-dark { justify-content: space-between; } }
+
+  .nav-tab-dark {
+    padding: var(--space-2, 0.5rem) var(--space-3, 0.75rem);
+    border-radius: calc(var(--radius, 0.375rem) - 2px);
+    color: hsl(var(--muted-foreground)); font-weight: var(--font-medium, 500);
+    font-size: var(--text-xs, 0.75rem); text-decoration: none;
+    transition: all var(--transition-normal, 200ms cubic-bezier(0.4, 0, 0.2, 1));
+    display: flex; align-items: center; gap: var(--space-1, 0.25rem);
+    border: none; background: none; cursor: pointer;
+    white-space: nowrap; flex-shrink: 0; min-width: fit-content;
+  }
+  @media (min-width: 640px) { .nav-tab-dark { padding: var(--space-3, 0.75rem) var(--space-4, 1rem); font-size: var(--text-sm, 0.875rem); gap: var(--space-2, 0.5rem); } }
+  @media (min-width: 1024px) { .nav-tab-dark { flex: 1; justify-content: center; min-width: 80px; } }
+  .nav-tab-dark:hover:not(.active) {
+    color: hsl(var(--foreground)); background-color: hsl(var(--accent) / 0.5);
+  }
+  .nav-tab-dark.active {
+    background-color: var(--color-primary-blue, hsl(var(--primary))); /* Fallback to theme primary */
+    color: var(--color-primary-blue-fg, hsl(var(--primary-foreground))); /* Fallback to theme primary-foreground */
+    box-shadow: var(--shadow-sm, 0 1px 2px 0 rgba(0,0,0,0.05));
+  }
+
+  /* General input, textarea, select styling from globals-dark.css - use with caution */
+  /* These are broad selectors. Prefer class-based styling or ShadCN components. */
+  /* input, textarea, select {
+    background-color: hsl(var(--input));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius-lg, 0.75rem);
+    padding: var(--space-3, 0.75rem) var(--space-4, 1rem);
+    font-family: var(--font-secondary, var(--font-sans));
+    font-size: var(--text-base, 1rem);
+    color: hsl(var(--foreground));
+    transition: all var(--transition-normal, 200ms cubic-bezier(0.4, 0, 0.2, 1));
+    width: 100%;
+  }
+  input:focus, textarea:focus, select:focus {
+    outline: none;
+    border-color: var(--color-primary-blue, hsl(var(--ring)));
+    box-shadow: 0 0 0 3px hsl(var(--ring) / 0.3);
+  }
+  input::placeholder, textarea::placeholder {
+    color: hsl(var(--muted-foreground) / 0.7);
+  } */
+
+  .badge-dark { /* Base badge style */
+    display: inline-flex; align-items: center;
+    padding: var(--space-1, 0.25rem) var(--space-3, 0.75rem);
+    border-radius: var(--radius-full, 9999px);
+    font-size: var(--text-xs, 0.75rem); font-weight: var(--font-medium, 500);
+    text-transform: uppercase; letter-spacing: 0.5px;
+    border: 1px solid transparent; /* Base border */
+  }
+  .badge-success-dark {
+    background-color: var(--color-primary-green-bg, hsl(var(--color-success, #10B981)/0.1));
+    color: var(--color-success, #10B981);
+    border-color: var(--color-success, #10B981);
+  }
+  .badge-warning-dark {
+    background-color: hsl(var(--color-warning, #F59E0B)/0.1);
+    color: var(--color-warning, #F59E0B);
+    border-color: var(--color-warning, #F59E0B);
+  }
+  .badge-error-dark {
+    background-color: hsl(var(--color-error, #EF4444)/0.1);
+    color: var(--color-error, #EF4444);
+    border-color: var(--color-error, #EF4444);
+  }
+  .badge-info-dark {
+    background-color: var(--color-primary-blue-bg, hsl(var(--color-info, #3B82F6)/0.1));
+    color: var(--color-info, #3B82F6);
+    border-color: var(--color-info, #3B82F6);
+  }
+
+  .chart-container-dark {
+    background-color: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius-xl, 1rem);
+    padding: var(--space-6, 1.5rem);
+    box-shadow: var(--shadow-md, 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06));
+    overflow: hidden;
+  }
+
+  .grid-responsive {
+    display: grid; gap: var(--space-6, 1.5rem); grid-template-columns: 1fr;
+  }
+  @media (min-width: 640px) { .grid-responsive { grid-template-columns: repeat(2, 1fr); } }
+  @media (min-width: 1024px) { .grid-responsive { grid-template-columns: repeat(3, 1fr); } }
+  @media (min-width: 1280px) { .grid-responsive { grid-template-columns: repeat(4, 1fr); } }
+
+  .mobile-overlay {
+    position: fixed; inset: 0;
+    background-color: hsl(var(--background) / 0.8); /* Overlay with background color */
+    z-index: 40; display: block;
+  }
+  @media (min-width: 1024px) { .mobile-overlay { display: none; } }
+
+  .loading-spinner {
+    width: 24px; height: 24px;
+    border: 2px solid hsl(var(--border));
+    border-top: 2px solid var(--color-primary-blue, hsl(var(--primary)));
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+
+  .mobile-menu-btn {
+    display: flex; align-items: center; justify-content: center;
+    width: 40px; height: 40px; border: none; background: none;
+    color: hsl(var(--muted-foreground)); cursor: pointer;
+    border-radius: var(--radius-lg, 0.75rem);
+    transition: all var(--transition-normal, 200ms cubic-bezier(0.4, 0, 0.2, 1));
+  }
+  .mobile-menu-btn:hover {
+    background-color: hsl(var(--accent) / 0.5);
+    color: hsl(var(--accent-foreground));
+  }
+  @media (min-width: 1024px) { .mobile-menu-btn { display: none; } }
+
+  /* Utility classes from globals-dark.css - mapped to new theme vars */
+  .text-primary { color: hsl(var(--primary-foreground)); }
+  .text-secondary { color: hsl(var(--secondary-foreground)); }
+  .text-tertiary { color: hsl(var(--muted-foreground)); }
+  /* .text-muted is a Tailwind class, this would override. Avoid defining. */
+  /* Use .text-muted-foreground from Tailwind/ShadCN directly */
+
+  .bg-primary { background-color: hsl(var(--primary)); }
+  .bg-secondary { background-color: hsl(var(--secondary)); }
+  /* .bg-card is a Tailwind class. Avoid defining. */
+  .bg-elevated { background-color: hsl(var(--popover)); } /* popover often serves as elevated background */
+
+  .border-primary { border-color: hsl(var(--border)); }
+  .border-secondary { border-color: hsl(var(--input)); } /* input border often secondary border */
+
+  /* Dynamic Content Filling Helpers from globals-dark.css */
+  .dashboard-content > div:last-child {
+    flex: 1; display: flex; flex-direction: column; min-height: 0;
+  }
+  /* Styling Tailwind's space classes directly is not standard. Remove these. */
+  /* .dashboard-content .space-y-6, .dashboard-content .space-y-4 {
+    height: 100%; display: flex; flex-direction: column; gap: var(--space-6, 1.5rem);
+  } */
+  .dashboard-content .grid { /* This is too generic. Avoid. */
+    /* flex: 1; align-content: start; */
   }
 }
 
-/* Custom utilities */
+/* Keyframes (merged) */
+@keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+@keyframes slideIn { from { transform: translateX(-100%); } to { transform: translateX(0); } }
+@keyframes pulse { /* For animate-pulse-slow if not provided by Tailwind */
+  0%, 100% { opacity: 1; }
+  50% { opacity: .5; }
+}
+@keyframes slideUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes scaleIn { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
+@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+
 @layer utilities {
+  /* Original utilities from globals.css */
   .text-gradient {
     @apply bg-gradient-to-r from-emerald-600 via-violet-600 to-amber-600 bg-clip-text text-transparent;
   }
-
   .glass-effect {
-    @apply bg-background/80 backdrop-blur-sm border border-border/50;
+    @apply bg-background/80 backdrop-blur-sm border border-border/50; /* Uses new theme vars */
   }
-
   .trading-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 1rem;
   }
-
   .dashboard-grid {
     display: grid;
     grid-template-columns: 250px 1fr;
     grid-template-rows: auto 1fr;
     min-height: 100vh;
   }
-
   .sidebar-grid {
     grid-column: 1;
     grid-row: 1 / -1;
   }
-
-  .main-content {
+  .main-content { /* This is from original utilities. It might conflict or co-exist with component .main-content */
     grid-column: 2;
     grid-row: 1 / -1;
   }
-
   @media (max-width: 768px) {
     .dashboard-grid {
       grid-template-columns: 1fr;
       grid-template-rows: auto auto 1fr;
     }
-    
     .sidebar-grid {
       grid-column: 1;
       grid-row: 2;
     }
-    
-    .main-content {
+    .main-content { /* from original utilities */
       grid-column: 1;
       grid-row: 3;
+    }
+  }
+  /* High contrast and reduced motion from globals-dark.css, moved to utilities */
+  @media (prefers-contrast: high) {
+    :root, .dark, .green, .neo, .cyber { /* Apply to all themes */
+      /* Example high contrast adjustments: increase text lightness on dark backgrounds */
+      /* This needs careful theme-specific consideration, providing a generic example */
+      --foreground: oklch(0.95 0 0); /* Brighter foreground */
+      --card-foreground: oklch(0.95 0 0);
+      --muted-foreground: oklch(0.85 0 0);
+      --border: oklch(0.7 0 0); /* Brighter borders */
+    }
+    .dark, .green.dark, .neo.dark, .cyber.dark {
+      --foreground: oklch(0.1 0 0); /* Darker foreground on light backgrounds if a theme switches */
+      --card-foreground: oklch(0.1 0 0);
+      --muted-foreground: oklch(0.2 0 0);
+      --border: oklch(0.3 0 0);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
     }
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
-import "./globals-dark.css";
 import ErrorBoundary from "@/lib/error-handling/error-boundary";
 import { ThemeProvider } from "@/components/theme-provider";
 


### PR DESCRIPTION
This commit addresses a critical issue where the dashboard was appearing entirely white and Shadcn UI components were not reflecting the intended theming (particularly the default dark theme).

The main changes include:

1.  **Consolidated CSS Variable Definitions:**
    - All theme-related CSS variables (for light, dark, green, neo, cyber themes using oklch color definitions) are now centralized in `src/app/globals.css`.
    - This resolves conflicts caused by redundant and overriding variable definitions that were present in `src/app/globals-dark.css`.

2.  **Removed Problematic Stylesheet Import:**
    - The import of `src/app/globals-dark.css` has been removed from `src/app/layout.tsx`. This file's relevant theme definitions were merged into `globals.css`.

3.  **Eliminated Harmful Global Overrides:**
    - Removed aggressive global style overrides and `!important` flags (previously in `globals-dark.css`) that were forcing specific background colors and interfering with the `next-themes` functionality. The standard `body { @apply bg-background text-foreground; }` in `globals.css` will now correctly apply theme-based backgrounds.

4.  **Integrated Component Styles:**
    - Useful component-specific styles from the former `globals-dark.css` have been integrated into the `@layer components` section of `src/app/globals.css`.

These changes ensure that the `ThemeProvider` from `next-themes` can correctly apply theme classes (e.g., `.dark`, `.green`) to the `<html>` element, which in turn activates the appropriate CSS variables. This allows Tailwind CSS and Shadcn UI components to render with the correct styling based on the active theme, resolving the "all white" appearance and restoring proper theming behavior site-wide.